### PR TITLE
refactor: Include an overlay in terms of default.nix

### DIFF
--- a/.github/workflows/nix-build-and-cache.yml
+++ b/.github/workflows/nix-build-and-cache.yml
@@ -76,7 +76,7 @@ jobs:
           name: gh-nix-idris2-packages
           # If you chose API tokens for write access OR if you have a private cache
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: Restore Cache 
+      - name: Restore Cache
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -97,4 +97,3 @@ jobs:
 
           cd ../../examples/non-flake-build-idris-prime
           nix-build
-

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
       nixpkgs,
       idris2,
       idris2Lsp,
+      self,
       ...
     }:
     let
@@ -41,6 +42,16 @@
         );
     in
     {
+      overlays =
+        let
+          mkOverlay = withSource: import ./overlay.nix { inherit idris2 idris2Lsp withSource; };
+        in
+        {
+          withoutSource = mkOverlay false;
+          withSource = mkOverlay true;
+          default = self.overlays.withSource;
+        };
+
       packages = lib.mapAttrs (
         n: attrs:
         (

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,32 @@
+# Provide an overlay that overrides the nixpkgs versions of the idris2 tools
+# with the versions exposed from this flake.
+{
+  idris2,
+  idris2Lsp,
+  withSource,
+}:
+final: prev:
+let
+  packages = import ./default.nix {
+    inherit (prev) system;
+    inherit withSource;
+    pkgs = prev;
+    idris2Override = idris2.packages.${prev.system}.idris2;
+    idris2SupportOverride = idris2.packages.${prev.system}.support;
+    idris2LspOverride = idris2Lsp.packages.${prev.system}.idris2Lsp;
+    buildIdrisOverride = idris2.buildIdris.${prev.system};
+  };
+in
+{
+  idris2Packages = prev.idris2Packages // {
+    inherit (packages)
+      buildIdris
+      buildIdris'
+      idris2
+      idris2Api
+      idris2Lsp
+      ;
+    packdb = packages.idris2Packages;
+  };
+  idris2 = final.idris2Packages.idris2;
+}


### PR DESCRIPTION
This provides an overlay and attempts to use it to assist in providing the flake outputs.

@mattpolzin I'm not sure this facilitates the original full non-flake workflow, and I'm happy to make any necessary tweaks to keep them working, although I think the overlay might also help to provide a more conventional approach of making the packages available to non-flake users.

One thing that might be a little awkward for non-flake users is that the overlay currently requires providing the `idris2` and `idris2Lsp` inputs to construct it. Ideally the `idris2` and `idris2Lsp` flakes would also provide minimal overlays which would make this unnecessary - maybe I can look into this next, or before landing this if necessary to keep the non-flake workflow going.

Closes #17 