### PR TITLE
mark async-posix as not broken on macos

### DIFF
--- a/idris2-pack-db/overrides.nix
+++ b/idris2-pack-db/overrides.nix
@@ -33,11 +33,6 @@
     meta.platforms = lib.platforms.linux;
   };
 
-  async-posix = {
-    # see https://github.com/stefan-hoeck/idris2-async/issues/78
-    meta.broken = stdenv.isDarwin;
-  };
-
   base64 = {
     meta.broken = stdenv.isAarch64 || stdenv.isAarch32;
   };


### PR DESCRIPTION
Mark async-posix as not broken for macos. 