### PR TITLE
Fix pg-idris nix derivation

### DIFF
--- a/idris2-pack-db/overrides.nix
+++ b/idris2-pack-db/overrides.nix
@@ -163,7 +163,7 @@
   };
 
   pg-idris = {
-    buildInputs = [ postgresql.dev ];
+    buildInputs = [ postgresql.dev postgresql.pg_config ];
   };
 
   posix = {


### PR DESCRIPTION
nixpkgs moved pg_config out of the root postgresql derivation and into a new
standalone package. This PR adds pg_config as a build input.
